### PR TITLE
Set a default value for get_option to avoid PHP errors

### DIFF
--- a/includes/class-sqlite-object-cache.php
+++ b/includes/class-sqlite-object-cache.php
@@ -134,7 +134,7 @@ class SQLite_Object_Cache {
 		// Handle localisation.
 		$this->load_plugin_textdomain();
 		add_action( 'init', [ $this, 'load_localization' ], 0 );
-		$option = get_option( $this->_token . '_settings' );
+		$option = get_option( $this->_token . '_settings', [] );
 		if ( array_key_exists( 'capture', $option ) && $option['capture'] === 'on' ) {
 			add_action( 'init', [ $this, 'do_capture' ] );
 		}


### PR DESCRIPTION
As soon as I activated the plugin I got some PHP warnings like `PHP Warning:  array_key_exists() expects parameter 2 to be array, bool given in /var/www/src/wp-content/plugins/sqlite-object-cache/includes/class-sqlite-object-cache.php on line 138`
That's because `get_option` returns false if the value hasn't already been set, so the `array_key_exists` call fails. Adding a default value in the `get_option` fixes the issue.