### PR TITLE
Update class-sqlite-object-cache-statistics.php

### DIFF
--- a/includes/lib/class-sqlite-object-cache-statistics.php
+++ b/includes/lib/class-sqlite-object-cache-statistics.php
@@ -19,7 +19,7 @@ class SQLite_Object_Cache_Statistics {
 	 *
 	 * @var array
 	 */
-	public $selected_names;
+	public $selected_names = [];
 
 	/**
 	 * Associative array with descriptive statistics.


### PR DESCRIPTION
As soon as I go to the stats page I'm getting this: `Warning: count(): Parameter must be an array or an object that implements Countable in /var/www/src/wp-content/plugins/sqlite-object-cache/includes/lib/class-sqlite-object-cache-statistics.php on line 340`

Adding a default value fixes the issue.