### PR TITLE
Ensure connection before deleting by name

### DIFF
--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -1903,13 +1903,13 @@ if ( ! defined( 'WP_SQLITE_OBJECT_CACHE_DISABLED' ) || ! WP_SQLITE_OBJECT_CACHE_
 		 * @return void
 		 */
 		private function delete_by_name( $name ) {
-			$start = $this->time_usec();
-			$stmt  = $this->deleteone;
 			try {
 				$this->not_in_persistent_cache[ $name ] = true;
 				if ( ! $this->sqlite ) {
 					$this->open_connection();
 				}
+				$start = $this->time_usec();
+				$stmt  = $this->deleteone;
 				$stmt->bindValue( ':name', $name, SQLITE3_TEXT );
 				$result = $stmt->execute();
 				$result->finalize();


### PR DESCRIPTION
Experiencing random 500 errors where the connection is no longer open and the statement is being created against a closed connection.

Moved the statement creation below the connection check and it appears to be resolved.