### PR TITLE
Ensure SQLite connections are closed

### DIFF
--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -434,6 +434,16 @@ if ( ! defined( 'WP_SQLITE_OBJECT_CACHE_DISABLED' ) || ! WP_SQLITE_OBJECT_CACHE_
     }
 
     /**
+     * Make sure connections are always closed at end of request
+     */
+    public function __destruct()
+    {
+      if ($this->sqlite) {
+        $this->sqlite->close();
+      }
+    }
+	  
+    /**
      * Load translations early if necessary and possible.
      *
      * @return bool


### PR DESCRIPTION
Fixes #44

Forces any lingering open SQLite connections to be closed at end of request, regardless of how the request was terminated.