### PR TITLE
Test whether the actually configured directory is writable

### DIFF
--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -616,6 +616,12 @@ if ( ! defined( 'WP_SQLITE_OBJECT_CACHE_DISABLED' ) || ! WP_SQLITE_OBJECT_CACHE_
         }
       }
 
+      $directory = dirname( $result );
+      if ( ! wp_is_writable( $directory ) ) {
+          $message = sprintf( 'The SQLite Object Cache cannot be activated because the %s directory is not writable.', $directory );
+          WP_Object_Cache::drop_dead( $message );
+      }
+
       return $result;
     }
 
@@ -922,14 +928,9 @@ if ( ! defined( 'WP_SQLITE_OBJECT_CACHE_DISABLED' ) || ! WP_SQLITE_OBJECT_CACHE_
     /**
      * Determine whether we can use SQLite3.
      *
-     * @param string $directory The directory to hold the .sqlite file. Default WP_CONTENT_DIR.
-     *
      * @return bool|string true, or an error message.
      */
-    public static function has_sqlite( $directory = WP_CONTENT_DIR ) {
-      if ( ! wp_is_writable( $directory ) ) {
-        return sprintf( 'The SQLite Object Cache cannot be activated because the %s directory is not writable.', $directory );
-      }
+    public static function has_sqlite() {
 
       if ( ! class_exists( 'SQLite3' ) || ! extension_loaded( 'sqlite3' ) ) {
         return 'The SQLite Object Cache cannot be activated because the SQLite3 extension is not loaded.';


### PR DESCRIPTION
The static method `has_sqlite()` incorrectly hardcoded the test for `wp-content/`. But if the configuration specified a different directory, via `WP_SQLITE_OBJECT_CACHE_DB_FILE`, then the test had no value. And even worse if the `wp-content/` is made read-only for security purposes, then the plugin could never work at all.

By moving the test within the `WP_Object_Cache` instance, we have access to the actual path to the file, and thus we can test the actual directory.