### PR TITLE
Allow DB file to be group writable for WP-CLI

### DIFF
--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -722,6 +722,12 @@ class WP_Object_Cache {
    */
   private function actual_open_connection() {
     $start        = hrtime( true );
+
+    // Create file manually to set correct file permission, that might be influenced by umask, and possibly make the DB group writable
+    if ( ! file_exists( $this->sqlite_path )) {
+      touch( $this->sqlite_path );
+    }
+
     $this->sqlite = new SQLite3( $this->sqlite_path, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, '' );
     $this->sqlite->enableExceptions( true );
     $this->sqlite->busyTimeout( $this->sqlite_timeout );


### PR DESCRIPTION
We want to allow the usage of WP-CLI, and in some setup that means the WP-CLI requires group permissions to read and write to the SQLite3 file. Without those permissions any WP-CLI usage would crash.

But when SQLite3 creates the file on disk it will use file permissions that are hardcoded during the compilation of SQLite3 (via `SQLITE_DEFAULT_FILE_PERMISSIONS`). The default value is `0644`, and that would make the file not writable by WP-CLI. Instead, we need `0660` to make the DB writable. But is not realistic to re-compile SQLite3 for most people.

By creating the file manually, we allow the normal file permissions to be applied (possibly controlled via `setfacl` on the containing folder). And thus we allow the usage of WP-CLI.

See: https://www.sqlite.org/compile.html#default_file_permissions
See also: https://stackoverflow.com/a/54091067/37706