### PR TITLE
Overhaul/simplify how object cache groups are handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The plugin offers a few optional settings for your `wp-config.php` file. Do not 
 * WP_SQLITE_OBJECT_CACHE_APCU. If true enables cache acceleration with APCu RAM. This setting can be updated from the plugin's Settings page.
 * WP_SQLITE_OBJECT_CACHE_CHECKPOINT_FREQ. How often, probabilistically, to force checkpointing SQLite3. Make this number smaller on busy sites if your WAL file gets too long. Default 2000.
 * WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS. An array of cache group names that should not be persisted to SQLite (memory-only cache). These are merged with any groups already marked as non-persistent. Example: `define( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS', ['my-group', 'another-group'] );`
+* WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS. An array of cache group names that will be persisted to SQLite but survive `wp_cache_flush()`. These are merged with any groups already marked as unflushable. Example: `define( 'WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS', ['my-group', 'another-group'] );`
 * WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY. The WordPress capability required to access the plugin's settings page and flush controls. Default: `manage_options`. Example: `define( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY', 'manage_network_options' );`
 * WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well. 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Author: Oliver Jones
 **Contributors:** OllieJones \
 **Tags:** cache, object cache, sqlite, performance, apcu \
 **Requires at least:** 5.5 \
-**Requires PHP:** 5.6 \
+**Requires PHP:** 7.0 \
 **Tested up to:** 7.0 \
 Version: 1.6.4 \
 **Stable tag:** 1.6.4 \
@@ -95,11 +95,11 @@ The plugin offers a few optional settings for your `wp-config.php` file. Do not 
 * WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS. An array of cache group names that should not be persisted to SQLite (memory-only cache). These are merged with any groups already marked as non-persistent. Example: `define( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS', ['my-group', 'another-group'] );`
 * WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS. An array of cache group names that will be persisted to SQLite but survive `wp_cache_flush()`. These are merged with any groups already marked as unflushable. Example: `define( 'WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS', ['my-group', 'another-group'] );`
 * WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY. The WordPress capability required to access the plugin's settings page and flush controls. Default: `manage_options`. Example: `define( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY', 'manage_network_options' );`
-* WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well. 
+* WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well.
 
 <h4>Configuring the cache key salt</h4>
 
-When multiple sites share the same server hardware and software, they can sometimes share the same cache data. Setting `WP_CACHE_KEY_SALT` to a hard-to-guess random value for each site makes it much harder for one site to get another site's data. This works for other cache plugins too. Notice that this `WP_CACHE_KEY_SALT` value must be set, in your site's `wp-config.php` file, before activating any cache plugin, including page caches and persistent object caches. 
+When multiple sites share the same server hardware and software, they can sometimes share the same cache data. Setting `WP_CACHE_KEY_SALT` to a hard-to-guess random value for each site makes it much harder for one site to get another site's data. This works for other cache plugins too. Notice that this `WP_CACHE_KEY_SALT` value must be set, in your site's `wp-config.php` file, before activating any cache plugin, including page caches and persistent object caches.
 
 To set the value put a line like this in `wp-config.php`.
 
@@ -147,11 +147,11 @@ Notice that this setting controls the size of the data in the cache. That is the
 
 ### What is APCu?
 
-[APCu](https://www.php.net/manual/en/book.apcu.php) is php extension offering an in-memory storage medium. You can configure this plugin to use it to speed up cache lookups. 
+[APCu](https://www.php.net/manual/en/book.apcu.php) is php extension offering an in-memory storage medium. You can configure this plugin to use it to speed up cache lookups.
 
 ### On my server the APCu shared memory cache is too small. How can I make it bigger?
 
-On most operating systems the size of the APCu cache is, as installed, 32MiB. If you need to increase this size you can add a line to your `php.ini` file mentioning the [apc.shm_size](https://www.php.net/manual/en/apcu.configuration.php#ini.apcu.shm-size) configuration option. For example, the line `apc.shm_size = 64M` sets the size to 64MiB. Please consult your operating system or hosting provider documetation for information on how to do this. 
+On most operating systems the size of the APCu cache is, as installed, 32MiB. If you need to increase this size you can add a line to your `php.ini` file mentioning the [apc.shm_size](https://www.php.net/manual/en/apcu.configuration.php#ini.apcu.shm-size) configuration option. For example, the line `apc.shm_size = 64M` sets the size to 64MiB. Please consult your operating system or hosting provider documetation for information on how to do this.
 
 Notice that sometimes multiple WordPress installations that run on the same server share the same APCu cache, so provide enough space for them all. And keep in mind that this plugin only uses APCu to accelerate its operations, so the consequences of setting its size too small are not great.
 
@@ -257,7 +257,7 @@ causes your object cache data to go into the `/tmp` folder in a file named `mysi
 
 ### Can this plugin use SQLite memory-mapped I/O?
 
-**Yes**. You can use your OS's memory map feature to access and share cache data with [SQLite Memory-Mapped I/O](https://www.sqlite.org/mmap.html). On some server configurations this allows multiple php processes to share cached data more quickly. In the plugin this is disabled by default. You can enable it by telling the plugin how many MiB to use for memory mapping. For example, this wp-config setting tells the plugin to use 32MiB. 
+**Yes**. You can use your OS's memory map feature to access and share cache data with [SQLite Memory-Mapped I/O](https://www.sqlite.org/mmap.html). On some server configurations this allows multiple php processes to share cached data more quickly. In the plugin this is disabled by default. You can enable it by telling the plugin how many MiB to use for memory mapping. For example, this wp-config setting tells the plugin to use 32MiB.
 
 `define( 'WP_SQLITE_OBJECT_CACHE_MMAP_SIZE', 32 );`
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The plugin offers a few optional settings for your `wp-config.php` file. Do not 
 * WP_SQLITE_OBJECT_CACHE_JOURNAL_MODE. This is the [SQLite journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode). Default: ‘WAL’. Possible values DELETE | TRUNCATE | PERSIST | MEMORY | WAL | WAL2 | NONE. (Not all SQLite3 implementations handle WAL2.)
 * WP_SQLITE_OBJECT_CACHE_APCU. If true enables cache acceleration with APCu RAM. This setting can be updated from the plugin's Settings page.
 * WP_SQLITE_OBJECT_CACHE_CHECKPOINT_FREQ. How often, probabilistically, to force checkpointing SQLite3. Make this number smaller on busy sites if your WAL file gets too long. Default 2000.
+* WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS. An array of cache group names that should not be persisted to SQLite (memory-only cache). These are merged with any groups already marked as non-persistent. Example: `define( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS', ['my-group', 'another-group'] );`
+* WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY. The WordPress capability required to access the plugin's settings page and flush controls. Default: `manage_options`. Example: `define( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY', 'manage_network_options' );`
 * WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well. 
 
 <h4>Configuring the cache key salt</h4>

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -9,7 +9,7 @@
  * Author URI: https://plumislandmedia.net
  * License: GPLv2+
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Requires PHP: 5.6
+ * Requires PHP: 7.0
  * Tested up to: 7.0
  * Stable tag: 1.6.4
  *

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -1594,7 +1594,7 @@ class WP_Object_Cache {
 
     $this->cache[ $name ] = $data;
 
-    if ( isset( $this->ignored_groups[ $group ?: 'default' ] ) ) {
+    if ( $this->is_ignored_group( $group ) ) {
       return true;
     }
 
@@ -1781,8 +1781,9 @@ class WP_Object_Cache {
    */
   public function get_multiple( $input_keys, $group = 'default', $force = false ) {
     $values = array();
-    if ( count( $input_keys ) <= 1 || $force ) {
-      /* Send the degenerate get_multiple calls, and forced calls, to plain old get. That logic is simpler. */
+    if ( count( $input_keys ) <= 1 || $force || $this->is_ignored_group( $group ) ) {
+      /* Send the degenerate get_multiple calls, and forced calls, to plain old get. That logic is simpler.
+       * Also use the simple path for ignored groups, since they are never stored in SQLite. */
       foreach ( $input_keys as $key ) {
         $values[ $key ] = $this->get( $key, $group, $force );
       }
@@ -2023,6 +2024,14 @@ class WP_Object_Cache {
 
         return is_object( $this->cache[ $name ] ) ? clone( $this->cache[ $name ] ) : $this->cache[ $name ];
       }
+      if ( $this->is_ignored_group( $group ) ) {
+        /* Ignored groups are never stored in SQLite; skip the persistent cache lookup. */
+        $found = false;
+        ++ $this->cache_misses;
+        ++ $this->get_depth;
+
+        return false;
+      }
       if ( $this->cache_item_exists( $name ) ) {
         $found = true;
         ++ $this->cache_hits;
@@ -2147,7 +2156,10 @@ class WP_Object_Cache {
 
     $name = $this->normalize_name( $key, $group );
     unset ( $this->cache[ $name ] );
-    $this->delete_by_name( $name );
+
+    if ( ! $this->is_ignored_group( $group ) ) {
+      $this->delete_by_name( $name );
+    }
 
     return true;
   }
@@ -2308,7 +2320,9 @@ class WP_Object_Cache {
     if ( $this->cache[ $name ] < 0 ) {
       $this->cache[ $name ] = 0;
     }
-    $this->put_by_name( $name, $this->cache[ $name ], 0 );
+    if ( ! $this->is_ignored_group( $group ) ) {
+      $this->put_by_name( $name, $this->cache[ $name ], 0 );
+    }
 
     return $this->cache[ $name ];
   }
@@ -2484,6 +2498,17 @@ class WP_Object_Cache {
     $groups = apply_filters( 'sqlite_object_cache_add_non_persistent_groups', (array) $groups );
 
     $this->ignored_groups = array_merge( $this->ignored_groups, array_fill_keys( $groups, true ) );
+  }
+
+  /**
+   * Checks if the given group is in the ignored (non-persistent) groups list.
+   *
+   * @param string $group Name of the group to check.
+   *
+   * @return bool
+   */
+  protected function is_ignored_group( $group ) {
+    return isset( $this->ignored_groups[ $group ?: 'default' ] );
   }
 
   /**

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -521,6 +521,10 @@ class WP_Object_Cache {
       : self::MMAP_SIZE;
     $this->mmap_size = (int) $this->mmap_size * 1024 * 1024;
 
+    if ( defined( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS' ) && is_array( WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS ) ) {
+      $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS ) );
+    }
+
     $this->multisite                 = is_multisite();
     $this->blog_prefix               = $this->multisite ? get_current_blog_id() . ':' : '';
     $this->cache_table_name          = self::OBJECT_CACHE_TABLE;

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -2025,7 +2025,7 @@ class WP_Object_Cache {
       $key = self::INTKEY_SENTINEL . str_pad( $key, 1 + $this->intkey_length, '0', STR_PAD_LEFT );
     }
 
-    if ( $this->multisite && ! isset( $this->global_groups[ $group ] ) ) {
+    if ( $this->multisite && ! in_array( $group, $this->global_groups, true ) ) {
       $key = $this->blog_prefix . $key;
     }
     if ( empty( $group ) ) {
@@ -2524,8 +2524,7 @@ class WP_Object_Cache {
   public function add_global_groups( $groups ) {
     $groups = (array) $groups;
 
-    $groups              = array_fill_keys( $groups, true );
-    $this->global_groups = array_merge( $this->global_groups, $groups );
+    $this->global_groups = array_unique(array_merge( $this->global_groups, $groups ));
 
     $this->cache_group_types();
   }
@@ -2562,7 +2561,7 @@ class WP_Object_Cache {
       $splits = explode( '|', $name, 2 );
       if ( 2 === count( $splits ) ) {
         $group = $splits[0];
-        if ( ! isset( $this->global_groups[ $group ] ) ) {
+        if ( ! in_array( $group, $this->global_groups, true ) ) {
           $names_to_flush[] = $name;
         }
       }

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -195,12 +195,6 @@ class WP_Object_Cache {
    */
   public $ignored_groups = array();
   /**
-   * List of groups and their types.
-   *
-   * @var array
-   */
-  public $group_type = array();
-  /**
    * Prefix used for global groups.
    *
    * @var string
@@ -478,7 +472,6 @@ class WP_Object_Cache {
     $this->start_hrtime = hrtime( true );
     $this->start_time   = time();
     global $table_prefix;
-    $this->cache_group_types();
 
     /* The environment. */
     $apc                  = defined( 'WP_SQLITE_OBJECT_CACHE_APCU' ) && WP_SQLITE_OBJECT_CACHE_APCU;
@@ -738,24 +731,6 @@ class WP_Object_Cache {
     $this->open_time = hrtime( true ) - $start;
   }
 
-  /**
-   * Set group type array
-   *
-   * @return void
-   */
-  protected function cache_group_types() {
-    foreach ( $this->global_groups as $group ) {
-      $this->group_type[ $group ] = 'global';
-    }
-
-    foreach ( $this->unflushable_groups as $group ) {
-      $this->group_type[ $group ] = 'unflushable';
-    }
-
-    foreach ( $this->ignored_groups as $group ) {
-      $this->group_type[ $group ] = 'ignored';
-    }
-  }
 
   /**
    * Do the necessary Data Definition Language work, for the cache table and flags table
@@ -1299,7 +1274,6 @@ class WP_Object_Cache {
     $groups = apply_filters( 'sqlite_object_cache_add_non_persistent_groups', (array) $groups );
 
     $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $groups ) );
-    $this->cache_group_types();
   }
 
   /**
@@ -1630,7 +1604,7 @@ class WP_Object_Cache {
 
     $this->cache[ $name ] = $data;
 
-    if ( $this->is_ignored_group( $group ) ) {
+    if ( in_array( $group, $this->ignored_groups, true ) ) {
       return true;
     }
 
@@ -2489,7 +2463,6 @@ class WP_Object_Cache {
     $groups = (array) $groups;
 
     $this->unflushable_groups = array_unique( array_merge( $this->unflushable_groups, $groups ) );
-    $this->cache_group_types();
   }
 
   /**
@@ -2503,8 +2476,6 @@ class WP_Object_Cache {
     $groups = (array) $groups;
 
     $this->global_groups = array_unique(array_merge( $this->global_groups, $groups ));
-
-    $this->cache_group_types();
   }
 
   /**
@@ -2574,39 +2545,6 @@ class WP_Object_Cache {
     return $this->apcu_active ? 'APCu|SQLite' : 'SQLite';
   }
 
-  /**
-   * Checks if the given group is part the ignored group array
-   *
-   * @param string $group Name of the group to check, pre-sanitized.
-   *
-   * @return bool
-   */
-  protected function is_ignored_group( $group ) {
-    return $this->is_group_of_type( $group, 'ignored' );
-  }
-
-  /**
-   * Checks the type of the given group
-   *
-   * @param string $group Name of the group to check, pre-sanitized.
-   * @param string $type Type of the group to check.
-   *
-   * @return bool
-   */
-  private function is_group_of_type( $group, $type ) {
-    return isset( $this->group_type[ $group ] ) && $this->group_type[ $group ] === $type;
-  }
-
-  /**
-   * Checks if the given group is part the global group array
-   *
-   * @param string $group Name of the group to check, pre-sanitized.
-   *
-   * @return bool
-   */
-  protected function is_global_group( $group ) {
-    return $this->is_group_of_type( $group, 'global' );
-  }
 
   /**
    * Get the names of the SQLite files.

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -522,11 +522,11 @@ class WP_Object_Cache {
     $this->mmap_size = (int) $this->mmap_size * 1024 * 1024;
 
     if ( defined( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS' ) && is_array( WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS ) ) {
-      $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS ) );
+      $this->add_non_persistent_groups( WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS );
     }
 
     if ( defined( 'WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS' ) && is_array( WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS ) ) {
-      $this->unflushable_groups = array_unique( array_merge( $this->unflushable_groups, WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS ) );
+      $this->add_unflushable_groups( WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS );
     }
 
     $this->multisite                 = is_multisite();
@@ -1594,7 +1594,7 @@ class WP_Object_Cache {
 
     $this->cache[ $name ] = $data;
 
-    if ( in_array( $group, $this->ignored_groups, true ) ) {
+    if ( isset( $this->ignored_groups[ $group ?: 'default' ] ) ) {
       return true;
     }
 
@@ -1967,7 +1967,7 @@ class WP_Object_Cache {
       $key = self::INTKEY_SENTINEL . str_pad( $key, 1 + $this->intkey_length, '0', STR_PAD_LEFT );
     }
 
-    if ( $this->multisite && ! in_array( $group, $this->global_groups, true ) ) {
+    if ( $this->multisite && ! isset( $this->global_groups[ $group ] ) ) {
       $key = $this->blog_prefix . $key;
     }
     if ( empty( $group ) ) {
@@ -2360,7 +2360,7 @@ class WP_Object_Cache {
 
       if ( $selective && is_array( $this->unflushable_groups ) && count( $this->unflushable_groups ) > 0 ) {
         $clauses = array();
-        foreach ( $this->unflushable_groups as $unflushable_group ) {
+        foreach ( array_keys( $this->unflushable_groups ) as $unflushable_group ) {
           $unflushable_group = sanitize_key( $unflushable_group );
           $clauses []        = "(name NOT LIKE '$unflushable_group|%')";
         }
@@ -2452,7 +2452,7 @@ class WP_Object_Cache {
   public function add_unflushable_groups( $groups ) {
     $groups = (array) $groups;
 
-    $this->unflushable_groups = array_unique( array_merge( $this->unflushable_groups, $groups ) );
+    $this->unflushable_groups = array_merge( $this->unflushable_groups, array_fill_keys( $groups, true ) );
   }
 
   /**
@@ -2465,11 +2465,11 @@ class WP_Object_Cache {
   public function add_global_groups( $groups ) {
     $groups = (array) $groups;
 
-    $this->global_groups = array_unique(array_merge( $this->global_groups, $groups ));
+    $this->global_groups = array_merge( $this->global_groups, array_fill_keys( $groups, true ) );
   }
 
   /**
-   * Sets the list of groups not to be cached by Redis.
+   * Sets the list of groups not to be cached by SQLite
    *
    * @param array $groups List of groups that are to be ignored.
    */
@@ -2483,7 +2483,7 @@ class WP_Object_Cache {
      */
     $groups = apply_filters( 'sqlite_object_cache_add_non_persistent_groups', (array) $groups );
 
-    $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $groups ) );
+    $this->ignored_groups = array_merge( $this->ignored_groups, array_fill_keys( $groups, true ) );
   }
 
   /**
@@ -2518,7 +2518,7 @@ class WP_Object_Cache {
       $splits = explode( '|', $name, 2 );
       if ( 2 === count( $splits ) ) {
         $group = $splits[0];
-        if ( ! in_array( $group, $this->global_groups, true ) ) {
+        if ( ! isset( $this->global_groups[ $group ] ) ) {
           $names_to_flush[] = $name;
         }
       }

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -525,6 +525,10 @@ class WP_Object_Cache {
       $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS ) );
     }
 
+    if ( defined( 'WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS' ) && is_array( WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS ) ) {
+      $this->unflushable_groups = array_unique( array_merge( $this->unflushable_groups, WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS ) );
+    }
+
     $this->multisite                 = is_multisite();
     $this->blog_prefix               = $this->multisite ? get_current_blog_id() . ':' : '';
     $this->cache_table_name          = self::OBJECT_CACHE_TABLE;
@@ -1260,24 +1264,6 @@ class WP_Object_Cache {
     $this->sqlite_version = $v['versionString'];
 
     return $this->sqlite_version;
-  }
-
-  /**
-   * Sets the list of groups not to be cached by Redis.
-   *
-   * @param array $groups List of groups that are to be ignored.
-   */
-  public function add_non_persistent_groups( $groups ) {
-    /**
-     * Filters list of groups to be added to {@see self::$ignored_groups}
-     *
-     * @param string[] $groups List of groups to be ignored.
-     *
-     * @since 2.1.7
-     */
-    $groups = apply_filters( 'sqlite_object_cache_add_non_persistent_groups', (array) $groups );
-
-    $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $groups ) );
   }
 
   /**
@@ -2480,6 +2466,24 @@ class WP_Object_Cache {
     $groups = (array) $groups;
 
     $this->global_groups = array_unique(array_merge( $this->global_groups, $groups ));
+  }
+
+  /**
+   * Sets the list of groups not to be cached by Redis.
+   *
+   * @param array $groups List of groups that are to be ignored.
+   */
+  public function add_non_persistent_groups( $groups ) {
+    /**
+     * Filters list of groups to be added to {@see self::$ignored_groups}
+     *
+     * @param string[] $groups List of groups to be ignored.
+     *
+     * @since 2.1.7
+     */
+    $groups = apply_filters( 'sqlite_object_cache_add_non_persistent_groups', (array) $groups );
+
+    $this->ignored_groups = array_unique( array_merge( $this->ignored_groups, $groups ) );
   }
 
   /**

--- a/assets/drop-in/object-cache.php
+++ b/assets/drop-in/object-cache.php
@@ -193,11 +193,7 @@ class WP_Object_Cache {
    *
    * @var array
    */
-  public $ignored_groups = array(
-    'counts',
-    'plugins',
-    'themes',
-  );
+  public $ignored_groups = array();
   /**
    * List of groups and their types.
    *
@@ -215,25 +211,7 @@ class WP_Object_Cache {
    *
    * @var array
    */
-  protected $global_groups = array(
-    'blog-details',
-    'blog-id-cache',
-    'blog-lookup',
-    'global-posts',
-    'networks',
-    'rss',
-    'sites',
-    'site-details',
-    'site-lookup',
-    'site-options',
-    'site-transient',
-    'users',
-    'useremail',
-    'userlogins',
-    'usermeta',
-    'user_meta',
-    'userslugs',
-  );
+  protected $global_groups = array();
 
   /**
    * @var array One-level associative array $name=>$value

--- a/includes/class-sqlite-object-cache-settings.php
+++ b/includes/class-sqlite-object-cache-settings.php
@@ -457,7 +457,7 @@ class SQLite_Object_Cache_Settings {
         'parent_slug' => 'options-general.php',
         'page_title'  => __( 'SQLite Persistent Object Cache', 'sqlite-object-cache' ),
         'menu_title'  => __( 'Object Cache', 'sqlite-object-cache' ),
-        'capability'  => 'manage_options',
+        'capability'  => SQLite_Object_Cache::get_manager_capability(),
         'menu_slug'   => $this->parent->_token . '_settings',
         'function'    => array( $this, 'settings_page' ),
         'icon_url'    => '',

--- a/includes/class-sqlite-object-cache.php
+++ b/includes/class-sqlite-object-cache.php
@@ -197,7 +197,10 @@ class SQLite_Object_Cache {
      * @return string Capability string.
      */
     public static function get_manager_capability() {
-        if ( defined( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY' ) && WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY ) {
+        if ( defined( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY' )
+            && is_string( WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY )
+            && '' !== WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY
+        ) {
             return WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY;
         }
         return 'manage_options';

--- a/includes/class-sqlite-object-cache.php
+++ b/includes/class-sqlite-object-cache.php
@@ -545,10 +545,10 @@ class SQLite_Object_Cache {
             // Multisite stores site transients in the sitemeta table.
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query(
-                    $wpdb->prepare(
-                    "DELETE FROM {$wpdb->sitemeta} WHERE a.meta_key LIKE %s",
-                            $wpdb->esc_like( '_site_transient_' ) . '%'
-                    )
+                $wpdb->prepare(
+                    "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s",
+                    $wpdb->esc_like( '_site_transient_' ) . '%'
+                )
             );
 
         }
@@ -601,7 +601,7 @@ class SQLite_Object_Cache {
         $updated_flag = array_key_exists( 'use_apcu_updated', $option );
         $use_apcu     = array_key_exists( 'use_apcu', $option ) && 'on' === $option['use_apcu'] ? 'on' : 'off';
         if ( $updated_flag ) {
-            unset ( $option['use_apcu_updated'] );
+            unset( $option['use_apcu_updated'] );
             $option_dirty = true;
         }
         $target_use_apcu = $this->apcu_is_activated() ? 'on' : 'off';
@@ -613,7 +613,7 @@ class SQLite_Object_Cache {
             $option_dirty       = true;
         }
         if ( $option_dirty ) {
-            if ( method_exists( $wp_object_cache, 'apcu-clear_cache' ) ) {
+            if ( method_exists( $wp_object_cache, 'apcu_clear_cache' ) ) {
                 $wp_object_cache->apcu_clear_cache();
             }
             update_option( $this->_token . '_settings', $option, true );

--- a/includes/class-sqlite-object-cache.php
+++ b/includes/class-sqlite-object-cache.php
@@ -183,12 +183,24 @@ class SQLite_Object_Cache {
         if ( array_key_exists ('adminbarflush', $option ) && 'on' === $option['adminbarflush'] ) {
             add_action( 'init', array( $this, 'handle_admin_bar_flush' ) );
             add_action ( 'init', function() {
-                if ( ! ( is_multisite() && ! is_main_site() ) &&  current_user_can( 'manage_options') ) {
+                if ( ! ( is_multisite() && ! is_main_site() ) &&  current_user_can( self::get_manager_capability() ) ) {
                     add_action( 'admin_bar_menu', array( $this, 'admin_bar_flush_button' ), 100 );
                     add_action( 'admin_notices', array( $this, 'maybe_show_flush_notice' ) );
                 }
             });
         }
+    }
+
+    /**
+     * Get the capability required to manage this plugin.
+     *
+     * @return string Capability string.
+     */
+    public static function get_manager_capability() {
+        if ( defined( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY' ) && WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY ) {
+            return WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY;
+        }
+        return 'manage_options';
     }
 
     /**
@@ -341,7 +353,6 @@ class SQLite_Object_Cache {
      *
      * @return bool
      * @author Till Krüss
-     *
      */
     public function initialize_filesystem( $url, $silent = false ) {
         require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -623,7 +634,7 @@ class SQLite_Object_Cache {
             return;
         }
 
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( self::get_manager_capability() ) ) {
             return;
         }
 
@@ -666,7 +677,7 @@ class SQLite_Object_Cache {
             return;
         }
 
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( self::get_manager_capability() ) ) {
             wp_die( esc_html__( 'You do not have permission to flush the object cache.', 'sqlite-object-cache' ) );
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Author: Oliver Jones
 Contributors: OllieJones
 Tags: cache, object cache, sqlite, performance, apcu
 Requires at least: 5.5
-Requires PHP: 5.6
+Requires PHP: 7.0
 Tested up to: 7.0
 Version: 1.6.4
 Stable tag: 1.6.4
@@ -94,11 +94,11 @@ The plugin offers a few optional settings for your `wp-config.php` file. Do not 
 * WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS. An array of cache group names that should not be persisted to SQLite (memory-only cache). These are merged with any groups already marked as non-persistent. Example: `define( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS', ['my-group', 'another-group'] );`
 * WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS. An array of cache group names that will be persisted to SQLite but survive `wp_cache_flush()`. These are merged with any groups already marked as unflushable. Example: `define( 'WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS', ['my-group', 'another-group'] );`
 * WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY. The WordPress capability required to access the plugin's settings page and flush controls. Default: `manage_options`. Example: `define( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY', 'manage_network_options' );`
-* WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well. 
+* WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well.
 
 <h4>Configuring the cache key salt</h4>
 
-When multiple sites share the same server hardware and software, they can sometimes share the same cache data. Setting `WP_CACHE_KEY_SALT` to a hard-to-guess random value for each site makes it much harder for one site to get another site's data. This works for other cache plugins too. Notice that this `WP_CACHE_KEY_SALT` value must be set, in your site's `wp-config.php` file, before activating any cache plugin, including page caches and persistent object caches. 
+When multiple sites share the same server hardware and software, they can sometimes share the same cache data. Setting `WP_CACHE_KEY_SALT` to a hard-to-guess random value for each site makes it much harder for one site to get another site's data. This works for other cache plugins too. Notice that this `WP_CACHE_KEY_SALT` value must be set, in your site's `wp-config.php` file, before activating any cache plugin, including page caches and persistent object caches.
 
 To set the value put a line like this in `wp-config.php`.
 
@@ -146,11 +146,11 @@ Notice that this setting controls the size of the data in the cache. That is the
 
 = What is APCu? =
 
-[APCu](https://www.php.net/manual/en/book.apcu.php) is php extension offering an in-memory storage medium. You can configure this plugin to use it to speed up cache lookups. 
+[APCu](https://www.php.net/manual/en/book.apcu.php) is php extension offering an in-memory storage medium. You can configure this plugin to use it to speed up cache lookups.
 
 = On my server the APCu shared memory cache is too small. How can I make it bigger? =
 
-On most operating systems the size of the APCu cache is, as installed, 32MiB. If you need to increase this size you can add a line to your `php.ini` file mentioning the [apc.shm_size](https://www.php.net/manual/en/apcu.configuration.php#ini.apcu.shm-size) configuration option. For example, the line `apc.shm_size = 64M` sets the size to 64MiB. Please consult your operating system or hosting provider documetation for information on how to do this. 
+On most operating systems the size of the APCu cache is, as installed, 32MiB. If you need to increase this size you can add a line to your `php.ini` file mentioning the [apc.shm_size](https://www.php.net/manual/en/apcu.configuration.php#ini.apcu.shm-size) configuration option. For example, the line `apc.shm_size = 64M` sets the size to 64MiB. Please consult your operating system or hosting provider documetation for information on how to do this.
 
 Notice that sometimes multiple WordPress installations that run on the same server share the same APCu cache, so provide enough space for them all. And keep in mind that this plugin only uses APCu to accelerate its operations, so the consequences of setting its size too small are not great.
 
@@ -256,7 +256,7 @@ causes your object cache data to go into the `/tmp` folder in a file named `mysi
 
 = Can this plugin use SQLite memory-mapped I/O?
 
-**Yes**. You can use your OS's memory map feature to access and share cache data with [SQLite Memory-Mapped I/O](https://www.sqlite.org/mmap.html). On some server configurations this allows multiple php processes to share cached data more quickly. In the plugin this is disabled by default. You can enable it by telling the plugin how many MiB to use for memory mapping. For example, this wp-config setting tells the plugin to use 32MiB. 
+**Yes**. You can use your OS's memory map feature to access and share cache data with [SQLite Memory-Mapped I/O](https://www.sqlite.org/mmap.html). On some server configurations this allows multiple php processes to share cached data more quickly. In the plugin this is disabled by default. You can enable it by telling the plugin how many MiB to use for memory mapping. For example, this wp-config setting tells the plugin to use 32MiB.
 
 `define( 'WP_SQLITE_OBJECT_CACHE_MMAP_SIZE', 32 );`
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,8 @@ The plugin offers a few optional settings for your `wp-config.php` file. Do not 
 * WP_SQLITE_OBJECT_CACHE_JOURNAL_MODE. This is the [SQLite journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode). Default: ‘WAL’. Possible values DELETE | TRUNCATE | PERSIST | MEMORY | WAL | WAL2 | NONE. (Not all SQLite3 implementations handle WAL2.)
 * WP_SQLITE_OBJECT_CACHE_APCU. If true enables cache acceleration with APCu RAM. This setting can be updated from the plugin's Settings page.
 * WP_SQLITE_OBJECT_CACHE_CHECKPOINT_FREQ. How often, probabilistically, to force checkpointing SQLite3. Make this number smaller on busy sites if your WAL file gets too long. Default 2000.
+* WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS. An array of cache group names that should not be persisted to SQLite (memory-only cache). These are merged with any groups already marked as non-persistent. Example: `define( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS', ['my-group', 'another-group'] );`
+* WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY. The WordPress capability required to access the plugin's settings page and flush controls. Default: `manage_options`. Example: `define( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY', 'manage_network_options' );`
 * WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well. 
 
 <h4>Configuring the cache key salt</h4>

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ The plugin offers a few optional settings for your `wp-config.php` file. Do not 
 * WP_SQLITE_OBJECT_CACHE_APCU. If true enables cache acceleration with APCu RAM. This setting can be updated from the plugin's Settings page.
 * WP_SQLITE_OBJECT_CACHE_CHECKPOINT_FREQ. How often, probabilistically, to force checkpointing SQLite3. Make this number smaller on busy sites if your WAL file gets too long. Default 2000.
 * WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS. An array of cache group names that should not be persisted to SQLite (memory-only cache). These are merged with any groups already marked as non-persistent. Example: `define( 'WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS', ['my-group', 'another-group'] );`
+* WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS. An array of cache group names that will be persisted to SQLite but survive `wp_cache_flush()`. These are merged with any groups already marked as unflushable. Example: `define( 'WP_SQLITE_OBJECT_CACHE_UNFLUSHABLE_GROUPS', ['my-group', 'another-group'] );`
 * WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY. The WordPress capability required to access the plugin's settings page and flush controls. Default: `manage_options`. Example: `define( 'WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY', 'manage_network_options' );`
 * WP_CACHE_KEY_SALT. Set this to a hard-to-guess random value to make your cache keys harder to guess. This setting works for other cache plugins as well. 
 

--- a/sqlite-object-cache.php
+++ b/sqlite-object-cache.php
@@ -7,7 +7,7 @@
  * Author: Oliver Jones
  * Author URI: https://github.com/OllieJones/
  * Requires at least: 5.5
- * Requires PHP: 5.6
+ * Requires PHP: 7.0
  * Tested up to: 7.0
  * Text Domain: sqlite-object-cache
  * Domain Path: /languages/


### PR DESCRIPTION
I've just noticed some peculiarities as well as opportunities for improvement/enhancement with how object cache groups are handled in this plugin.

---

Using xdebug, i can see that the value of $this->global_groups is 
```json
{
 "0": "blog-details",
 "1": "blog-id-cache",
 "2": "blog-lookup",
 "3": "global-posts",
 "4": "networks",
 "5": "rss",
 "6": "sites",
 "7": "site-details",
 "8": "site-lookup",
 "9": "site-options",
 "10": "site-transient",
 "11": "users",
 "12": "useremail",
 "13": "userlogins",
 "14": "usermeta",
 "15": "user_meta",
 "16": "userslugs",
 "blog-details": true,
 "blog-id-cache": true,
 "blog-lookup": true,
 "blog_meta": true,
 "global-posts": true,
 "image_editor": true,
 "networks": true,
 "network-queries": true,
 "sites": true,
 "site-details": true,
 "site-options": true,
 "site-queries": true,
 "site-transient": true,
 "theme_files": true,
 "translation_files": true,
 "rss": true,
 "users": true,
 "user-queries": true,
 "user_meta": true,
 "useremail": true,
 "userlogins": true,
 "userslugs": true
}
```
The issue comes from `add_global_groups()`, which (unlike `add_ignored/unflushable_groups()`) used `array_fill_keys` on incoming groups and didnt use `array_unique`. This aligns it with the other methods, and adjusts relevant code to check global_groups appropriate.

---

I also noticed that wp core's [load.php->wp_start_object_cache()](https://github.com/WordPress/wordpress-develop/blob/117af7e9a37c02ee17ac8f143cb46b6b0f4cde15/src/wp-includes/load.php#L901-L926) sets global and ignored groups, so there no value in setting them in the object cache (which also seemed to have a stale set of groups in its arrays...).

---

It also seems that `$group_types` is completely unnecessary. It was only actually being used by `is_ignored_group()`, which was only called from `set()`. Better to just check `$ignored_groups` directly and remove all the unnecessary code. Moreover, everything was protected/private except for the `public $group_types` array. I find it hard to imagine (and would perhaps actually discourage) that anyone has code referencing this variable. 

---

I also added `WP_SQLITE_OBJECT_CACHE_IGNORED_GROUPS` and `WP_SQLITE_OBJECT_CACHE_MANAGER_CAPABILITY` constants, inspired by Redis Object Cache. They just merge whatever is specified into the `ignored_groups` and `unflushable_groups` arrays.